### PR TITLE
Add institutional partners

### DIFF
--- a/people.md
+++ b/people.md
@@ -39,4 +39,5 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 ### Tier 1
 
-- [Continuum Analytics](http://continuum.io/) (Jeff Reback, Joris Van den Bossche)
+- [Continuum Analytics](https://www.continuum.io/) (Jeff Reback, Joris Van den Bossche)
+- [Two Sigma](https://www.twosigma.com/) (Wes McKinney)

--- a/people.md
+++ b/people.md
@@ -34,3 +34,9 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 - Joris Van den Bossche
 - Camille Scott
 - Nathaniel Smith
+
+## Institutional Partners
+
+### Tier 1
+
+- [Continuum Analytics](http://continuum.io/) (Jeff Reback, Joris Van den Bossche)

--- a/people.md
+++ b/people.md
@@ -40,4 +40,4 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 ### Tier 1
 
 - [Continuum Analytics](https://www.continuum.io/) (Jeff Reback, Joris Van den Bossche)
-- [Two Sigma](https://www.twosigma.com/) (Wes McKinney)
+- [Two Sigma](https://www.twosigma.com/) (Wes McKinney, Phillip Cloud)


### PR DESCRIPTION
Our governance docs say that institutional partners get "acknowledged on the pandas website" (among other things). The main website needs a general update, but I thought to already start adding them to the governance repo itself (similar to how they are listed in the jupyter governance repo).

I now added Continuum for Jeff and me, as I think Continuum matches the description of an institutional partner, as we both can do some pandas work during our working hours. Jeff, that is right?

To approve, maybe use the github thumb up

@wesm Should Two Sigma also be added to the list?

@pandas-dev/pandas-core others for who an institution should be mentioned?