### PR TITLE
Moving some core team members to inactive status

### DIFF
--- a/people.md
+++ b/people.md
@@ -12,12 +12,9 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 - Andy Hayden
 - Stephan Hoyer
 - Wes McKinney
-- Wouter Overmeire
 - Jeff Reback
-- Skipper Seabold
 - Chang She
 - Masaaki Horikoshi (@sinhrks)
-- Jeff Tratner
 - Joris Van den Bossche
 
 ## Project NumFOCUS Subcommittee
@@ -42,3 +39,9 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 - [Continuum Analytics](https://www.continuum.io/) (Jeff Reback, Joris Van den Bossche)
 - [Two Sigma](https://www.twosigma.com/) (Wes McKinney, Phillip Cloud)
+
+## Past Core Team Members
+
+- Wouter Overmeire
+- Skipper Seabold
+- Jeff Tratner


### PR DESCRIPTION
I've contacted some of the inactive core team members about returning to active status, and the ones in this patch have indicated they do not intend to become active again.

Since the governance documents provide a 1 year grace period, I will wait to hear back from the others about what they would like to do.

In the meantime, if the current core team can vote:

- [+1] I support these changes
- [-1] I do not support these changes

My vote: +1