### PR TITLE
Adding Gousto (Marco Gorelli) as Institutional Partner

### DIFF
--- a/people.md
+++ b/people.md
@@ -6,7 +6,25 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 ## Project Core Team
 
-See [team](https://pandas.pydata.org/about/team.html) for up-to-date list of maintainers.
+- Tom Augspurger
+- William Ayd
+- Chris Bartak
+- Pietro Battiston
+- Phillip Cloud
+- Marc Garcia
+- Andy Hayden
+- Masaaki Horikoshi (@sinhrks)
+- Simon Hawkins
+- Stephan Hoyer
+- Wes McKinney
+- Brock Mendel
+- Terji Petersen
+- Jeff Reback
+- Matthew Roeschke
+- Jeremy Schendel
+- Chang She
+- Joris Van den Bossche
+- G. Young
 
 ## Project NumFOCUS Subcommittee
 

--- a/people.md
+++ b/people.md
@@ -6,25 +6,7 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 ## Project Core Team
 
-- Tom Augspurger
-- William Ayd
-- Chris Bartak
-- Pietro Battiston
-- Phillip Cloud
-- Marc Garcia
-- Andy Hayden
-- Masaaki Horikoshi (@sinhrks)
-- Simon Hawkins
-- Stephan Hoyer
-- Wes McKinney
-- Brock Mendel
-- Terji Petersen
-- Jeff Reback
-- Matthew Roeschke
-- Jeremy Schendel
-- Chang She
-- Joris Van den Bossche
-- G. Young
+See [team](https://pandas.pydata.org/about/team.html) for up-to-date list of maintainers.
 
 ## Project NumFOCUS Subcommittee
 
@@ -51,6 +33,7 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 - [Two Sigma](https://www.twosigma.com/) (Phillip Cloud, Jeff Reback)
 - [RStudio](https://www.rstudio.com) (Wes McKinney)
 - [Ursa Labs](https://ursalabs.org) (Wes McKinney, Joris Van den Bossche)
+- [Gousto](https://www.gousto.co.uk/) (Marco Gorelli)
 
 ## Past Core Team Members
 


### PR DESCRIPTION
1. Rather than keeping a list of people up-to-date in two places, I'd suggest linking to the website from here
2. My current employer (Gousto) runs a "tech ten percent" scheme, and they've said they're happy for me to spend part of that time working on pandas - this would be one Friday every other week. Per the [governance.md#institutional-partners-and-funding](https://github.com/pandas-dev/pandas-governance/blob/master/governance.md#institutional-partners-and-funding) document, my understanding is that I could/should list them here