### PR TITLE
Update Institutional Partners: remove Anaconda and RStudio

### DIFF
--- a/people.md
+++ b/people.md
@@ -47,7 +47,7 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 ### Tier 1
 
-- [Two Sigma](https://www.twosigma.com/) (Phillip Cloud, Jeff Reback)
+- [Two Sigma](https://www.twosigma.com/) (Jeff Reback)
 - [Ursa Labs](https://ursalabs.org) (Wes McKinney, Joris Van den Bossche)
 - [Gousto](https://www.gousto.co.uk/) (Marco Gorelli)
 

--- a/people.md
+++ b/people.md
@@ -47,9 +47,7 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 
 ### Tier 1
 
-- [Anaconda, Inc.](https://www.anaconda.com/) (Tom Augspurger, Brock Mendel)
 - [Two Sigma](https://www.twosigma.com/) (Phillip Cloud, Jeff Reback)
-- [RStudio](https://www.rstudio.com) (Wes McKinney)
 - [Ursa Labs](https://ursalabs.org) (Wes McKinney, Joris Van den Bossche)
 - [Gousto](https://www.gousto.co.uk/) (Marco Gorelli)
 

--- a/people.md
+++ b/people.md
@@ -60,3 +60,5 @@ Wes McKinney is the Benevolent Dictator for Life (BDFL).
 ## Past Institutional Partners
 
 - [Paris-Saclay Center for Data Science](https://www.datascience-paris-saclay.fr/)
+- [Anaconda, Inc.](https://www.anaconda.com/)
+- [RStudio](https://www.rstudio.com)


### PR DESCRIPTION
cc @TomAugspurger @jbrockmendel @wesm 

Tom, I think there is no longer someone employed at Anaconda directly involved in pandas? (also not a regular contributor, which would still count as "Tier 2" ?) That would mean we remove Anaconda from this list (and their logo from the website). Should we notify someone at Anaconda about this removal?

Wes, with Ursa Computing, I think you no longer have an official affiliation with RStudio, is that correct? (although they are of course still funders of Ursa Computing)

